### PR TITLE
fix: Remove duplicate event handlers causing doubled progress count

### DIFF
--- a/pages/practice.html
+++ b/pages/practice.html
@@ -93,13 +93,13 @@
                         
                         <!-- Submit and Navigation -->
                         <div class="question-actions" id="questionActions" style="display:none;">
-                            <button class="btn btn-primary" onclick="submitAnswers()" id="submitBtn">
+                            <button class="btn btn-primary" id="submitBtn">
                                 答えを確認
                             </button>
-                            <button class="btn btn-secondary" onclick="showExplanations()" id="explanationBtn" style="display:none;">
+                            <button class="btn btn-secondary" id="explanationBtn" style="display:none;">
                                 解説を見る
                             </button>
-                            <button class="btn btn-secondary" onclick="nextPassage()" id="nextBtn" style="display:none;">
+                            <button class="btn btn-secondary" id="nextBtn" style="display:none;">
                                 次の問題へ
                             </button>
                         </div>


### PR DESCRIPTION
Fixes #9

The submit, explanation, and next buttons had both inline onclick handlers and JavaScript addEventListener calls, causing each button click to fire twice. This resulted in progress being recorded twice, doubling the "解いた問題数" (problems solved) count in the recent learning history.

Changes:
- Removed onclick attributes from practice.html buttons
- Kept existing addEventListener handlers in practice.js
- Ensures each button action only fires once